### PR TITLE
Different env names, enables bindings for developers to the defined envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN wget -O /meta.yaml -q https://raw.githubusercontent.com/Open-MSS/MSS/${BRANC
    | sed -e "s/.*://" > reqs.txt \
   && cat development.txt >> reqs.txt \
   && echo pyvirtualdisplay >> reqs.txt \
-  && mamba create -y -n mssenv --file reqs.txt \
+  && mamba create -y -n mss-${BRANCH}-env --file reqs.txt \
   && conda clean --all \
   && rm reqs.txt \
   && cp /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN wget -O /meta.yaml -q https://raw.githubusercontent.com/Open-MSS/MSS/${BRANC
   && cat development.txt >> reqs.txt \
   && echo pyvirtualdisplay >> reqs.txt \
   && mamba create -y -n mss-${BRANCH}-env --file reqs.txt \
+  && mamba create -y -n mssenv --file reqs.txt \
   && conda clean --all \
   && rm reqs.txt \
   && cp /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh 


### PR DESCRIPTION
we keep until we merged develop to stable the old mssenv name too. 

related https://github.com/Open-MSS/MSS/issues/1678