### PR TITLE
Add xvfb-run to pytest invocation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,6 @@
 name: Update Image
 
-on: 
+on:
   workflow_call:
     inputs:
       branch_name:
@@ -16,8 +16,8 @@ env:
   IMAGE_PATH: openmss
   BRANCH_NAME: ${{ inputs.branch_name }}
   IMAGE_NAME: testing-${{ inputs.branch_name }}
-  
-jobs:     
+
+jobs:
   test-and-publish-testing:
     runs-on: ubuntu-latest
 
@@ -28,14 +28,14 @@ jobs:
         run: |
           set -x
           docker build . --build-arg BRANCH=$BRANCH_NAME --tag $IMAGE_PATH/$IMAGE_NAME:latest
-        
+
       - name: Print conda list
         run: |
           docker run $IMAGE_PATH/$IMAGE_NAME:latest /bin/bash -c "
           source /opt/conda/bin/activate mssenv &&
           conda list
           "
-        
+
       - name: Test image
         timeout-minutes: 30
         run: |
@@ -45,12 +45,12 @@ jobs:
           cd MSS &&
           git checkout $BRANCH_NAME &&
           source /opt/conda/bin/activate mssenv &&
-          pytest -k 'not (browse_add_operation or add_operation or skyfield_data_expiration or test_handle_db_reset or test_handle_db_seed or test_mscolab_)' \
+          xvfb-run pytest -k 'not (browse_add_operation or add_operation or skyfield_data_expiration or test_handle_db_reset or test_handle_db_seed or test_mscolab_)' \
           || (for i in {1..5} \
-            ; do pytest --last-failed --lfnf=none \
+            ; do xvfb-run pytest --last-failed --lfnf=none \
             && break \
           ; done)"
-          
+
       - name: Log into dockerhub
         run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_ACCOUNT }} --password-stdin
 


### PR DESCRIPTION
Due to the changes in https://github.com/Open-MSS/MSS/commit/9fac1b3af41b94858fcd639d418b81b440135c47 it is now required to run the test suite with xvfb-run, if GUI tests should be executed without a display. Hopefully this fixes the failures we are seeing right now.